### PR TITLE
fixed wrong merge workaround

### DIFF
--- a/src/Images/src/Images/Infrastructure/ImageTransferAdapterAbstractFactory.php
+++ b/src/Images/src/Images/Infrastructure/ImageTransferAdapterAbstractFactory.php
@@ -108,7 +108,7 @@ class ImageTransferAdapterAbstractFactory implements AbstractFactoryInterface
             return false;
         }
 
-        return array_merge_recursive($this->defaults, $config[$serviceConfigKey]);
+        return ArrayUtils::merge($this->defaults, $config[$serviceConfigKey], true);
     }
 
     /**


### PR DESCRIPTION
fixed merge with local config
Assume local config is like that:
```
'imageService.adapter' => [
        'default' => [
            'validators' => [
                \Zend\Validator\File\Size::class => ['max' => '5MB'],
            ],
        ],
    ],
```

Previously you'd get 
```
'imageService.adapter' => [
        'default' => [
            'validators' => [
                \Zend\Validator\File\Size::class => ['max' => ['2MB', '5MB']],
            ],
        ],
    ],
```
as a return of src/Images/src/Images/Infrastructure/ImageTransferAdapterAbstractFactory.php::getServiceConfig
That happens because array_merge_recursive merges same-key scalar values into single array instead of replace first scalar value with the second one.